### PR TITLE
Added web-vitals

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-document-load/src/enums/EventNames.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/enums/EventNames.ts
@@ -18,4 +18,7 @@ export enum EventNames {
   FIRST_PAINT = 'firstPaint',
   FIRST_CONTENTFUL_PAINT = 'firstContentfulPaint',
   LARGEST_CONTENTFUL_PAINT = 'largestContentfulPaint',
+  CUMULATIVE_LAYOUT_SHIFT = 'cumulativeLayoutShift',
+  FIRST_INPUT_DELAY = 'firstInputDelay',
+  TIME_TO_FIRST_BYTE = 'timeToFirstByte'
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
@@ -144,9 +144,9 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<unknown> {
       addSpanNetworkEvent(rootSpan, PTN.LOAD_EVENT_START, entries);
       addSpanNetworkEvent(rootSpan, PTN.LOAD_EVENT_END, entries);
 
-      addSpanPerformancePaintEvents(rootSpan);
-
-      this._endSpan(rootSpan, PTN.LOAD_EVENT_END, entries);
+      addSpanPerformancePaintEvents(rootSpan, () => {
+        this._endSpan(rootSpan, PTN.LOAD_EVENT_END, entries);
+      });
     });
   }
 

--- a/plugins/web/opentelemetry-instrumentation-document-load/src/utils.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/utils.ts
@@ -22,7 +22,7 @@ import {
   PerformanceLegacy,
   PerformanceTimingNames as PTN,
 } from '@opentelemetry/sdk-trace-web';
-import { getCLS, getFCP, getFID, getLCP, getTTFB, Metric } from 'web-vitals'
+import { getCLS, getFCP, getFID, getLCP, getTTFB, Metric } from 'web-vitals';
 import { EventNames } from './enums/EventNames';
 
 export const getPerformanceNavigationEntries = (): PerformanceEntries => {
@@ -67,7 +67,7 @@ const vitalsMetricNames: Record<Metric['name'], string> = {
   TTFB: EventNames.TIME_TO_FIRST_BYTE,
   LCP: EventNames.LARGEST_CONTENTFUL_PAINT,
   CLS: EventNames.CUMULATIVE_LAYOUT_SHIFT
-}
+};
 
 const performancePaintNames = {
   'first-paint': EventNames.FIRST_PAINT,
@@ -76,37 +76,38 @@ const performancePaintNames = {
 export const addSpanPerformancePaintEvents = (span: Span, callback: () => void) => {
   const missedMetrics: Set<Metric['name']> = new Set(['FCP', 'FID', 'TTFB'])
   if ('chrome' in globalThis) {
-    missedMetrics.add('LCP')
-    missedMetrics.add('CLS')
+    // LCP and CLS are only available in chromium according to web-vitals README
+    missedMetrics.add('LCP');
+    missedMetrics.add('CLS');
   }
 
-  let spanIsEnded = false
+  let spanIsEnded = false;
 
   const endSpan = () => {
-    document.removeEventListener('visibilitychange', endSpan)
-    globalThis.removeEventListener('pagehide', endSpan)
+    document.removeEventListener('visibilitychange', endSpan);
+    globalThis.removeEventListener('pagehide', endSpan);
     if (!spanIsEnded) {
-      spanIsEnded = true
-      callback()
+      spanIsEnded = true;
+      callback();
     }
   }
 
   const handleNewMetric = (metric: Metric) => {
-    missedMetrics.delete(metric.name)
-    span.addEvent(vitalsMetricNames[metric.name], metric.value)
+    missedMetrics.delete(metric.name);
+    span.addEvent(vitalsMetricNames[metric.name], metric.value);
     if (!missedMetrics.size) {
-      endSpan()
+      endSpan();
     }
   }
 
-  document.addEventListener('visibilitychange', endSpan)
-  globalThis.addEventListener('pagehide', endSpan)
+  document.addEventListener('visibilitychange', endSpan);
+  globalThis.addEventListener('pagehide', endSpan);
 
-  getCLS(handleNewMetric)
-  getFCP(handleNewMetric)
-  getFID(handleNewMetric)
-  getLCP(handleNewMetric)
-  getTTFB(handleNewMetric)
+  getCLS(handleNewMetric);
+  getFCP(handleNewMetric);
+  getFID(handleNewMetric);
+  getLCP(handleNewMetric);
+  getTTFB(handleNewMetric);
 
   const performancePaintTiming = (
     otperformance as unknown as Performance


### PR DESCRIPTION
Added `web-vitals` into the root `documentLoad` span. It's not perfect solution, because some of web-vitals metrics trigger far after documentLoad span ends, but currently we don't have a better way to support it.